### PR TITLE
Update setup for latest Zig version

### DIFF
--- a/.proxyrc.js
+++ b/.proxyrc.js
@@ -2,9 +2,9 @@ const { createReadStream } = require("fs");
 
 module.exports = function (app) {
 	app.use((req, res, next) => {
-        // res.setHeader("Cross-Origin-Opener-Policy", "same-origin");
-        // res.setHeader("Cross-Origin-Embedder-Policy", "require-corp");
-		// res.setHeader("Cross-Origin-Resource-Policy", "cross-origin");
+        res.setHeader("Cross-Origin-Opener-Policy", "same-origin");
+        res.setHeader("Cross-Origin-Embedder-Policy", "require-corp");
+		res.setHeader("Cross-Origin-Resource-Policy", "cross-origin");
 
 		if (req.url === "/zig.tar") {
 			res.setHeader("Content-Type", "application/octet-stream");

--- a/README.md
+++ b/README.md
@@ -5,11 +5,15 @@ Works pretty well in a bunch of browsers, but note the required security headers
 ## Installing
 
 * Compile zls for `wasm32-wasi` and place `zls.wasm` in `src`
-* Additionally, place `zig.tar` (make sure to un-xz and that the name matches) from the website in `src`
+* Additionally, place `zig.tar.gz` (make sure that the name matches) from the website in `src`
+  * If you've downloaded Zig and built from source following `ZIG_WASM.md`, you can also use this command:
+    ```bash
+    tar -C /path/to/zig -cz lib/std >src/zig.tar.gz
+    ```
 
 ```bash
-npm i -g parcel
-parcel 404.html
+npm install
+npm run serve
 ```
 
 Enjoy!

--- a/ZIG_WASM.md
+++ b/ZIG_WASM.md
@@ -6,23 +6,23 @@ Apply this patch:
 
 ```patch
 diff --git a/build.zig b/build.zig
-index 9926d6e5e..461a0c7af 100644
+index 9e6e86386..ec8b6b9bd 100644
 --- a/build.zig
 +++ b/build.zig
-@@ -204,7 +204,7 @@ pub fn build(b: *std.Build) !void {
-     exe_options.addOption(bool, "llvm_has_arc", llvm_has_arc);
+@@ -237,7 +237,7 @@ pub fn build(b: *std.Build) !void {
+     exe_options.addOption(bool, "llvm_has_xtensa", llvm_has_xtensa);
      exe_options.addOption(bool, "force_gpa", force_gpa);
      exe_options.addOption(bool, "only_c", only_c);
--    exe_options.addOption(bool, "omit_pkg_fetching_code", only_c);
-+    exe_options.addOption(bool, "omit_pkg_fetching_code", true);
- 
+-    exe_options.addOption(bool, "only_core_functionality", only_c);
++    exe_options.addOption(bool, "only_core_functionality", true);
+
      if (link_libc) {
          exe.linkLibC();
 diff --git a/src/link.zig b/src/link.zig
-index 45873fec2..43f4dc7d1 100644
+index 703dfb873..3bc4039e7 100644
 --- a/src/link.zig
 +++ b/src/link.zig
-@@ -761,9 +761,9 @@ pub const File = struct {
+@@ -765,9 +765,9 @@ pub const File = struct {
      /// Commit pending changes and write headers. Takes into account final output mode
      /// and `use_lld`, not only `effectiveOutputMode`.
      pub fn flush(base: *File, comp: *Compilation, prog_node: *std.Progress.Node) FlushError!void {
@@ -40,7 +40,7 @@ index c4fb9b829..7fdc018ab 100644
 --- a/src/link/Wasm/Archive.zig
 +++ b/src/link/Wasm/Archive.zig
 @@ -208,9 +208,9 @@ pub fn parseObject(archive: Archive, allocator: Allocator, file_offset: u32) !Ob
- 
+
      const object_name = try archive.parseName(header);
      const name = name: {
 -        var buffer: [std.fs.MAX_PATH_BYTES]u8 = undefined;
@@ -51,30 +51,30 @@ index c4fb9b829..7fdc018ab 100644
 +        break :name try std.fmt.allocPrint(allocator, "{s}({s})", .{ archive.name, object_name });
      };
      defer allocator.free(name);
- 
+
 diff --git a/src/main.zig b/src/main.zig
-index 76c43476e..05eae6722 100644
+index 39a7adc42..616518d15 100644
 --- a/src/main.zig
 +++ b/src/main.zig
-@@ -198,7 +198,7 @@ pub fn main() anyerror!void {
+@@ -200,7 +200,7 @@ pub fn main() anyerror!void {
      }
- 
+
      // Short circuit some of the other logic for bootstrapping.
 -    if (build_options.only_c) {
 +    if (true) {
          if (mem.eql(u8, args[1], "build-exe")) {
              return buildOutputType(gpa, arena, args, .{ .build = .Exe });
          } else if (mem.eql(u8, args[1], "build-obj")) {
-@@ -1522,7 +1522,7 @@ fn buildOutputType(
+@@ -1544,7 +1544,7 @@ fn buildOutputType(
              }
          },
          .cc, .cpp => {
 -            if (build_options.only_c) unreachable;
 +            if (true) unreachable;
- 
+
              emit_h = .no;
              soname = .no;
-@@ -3190,7 +3190,7 @@ fn buildOutputType(
+@@ -3238,7 +3238,7 @@ fn buildOutputType(
      switch (listen) {
          .none => {},
          .stdio => {
@@ -83,18 +83,19 @@ index 76c43476e..05eae6722 100644
              try serve(
                  comp,
                  std.io.getStdIn(),
-@@ -3250,7 +3250,7 @@ fn buildOutputType(
+@@ -3286,7 +3286,7 @@ fn buildOutputType(
          error.SemanticAnalyzeFail => if (listen == .none) process.exit(1),
          else => |e| return e,
      };
 -    if (build_options.only_c) return cleanExit();
 +    if (true) return cleanExit();
      try comp.makeBinFileExecutable();
- 
+
      if (test_exec_args.items.len == 0 and object_format == .c) default_exec_args: {
 ```
 
 then:
+
 ```bash
-../zig-from-website/zig build -Dtarget=wasm32-wasi -Drelease=true
+../zig-from-website/zig build -Dtarget=wasm32-wasi -Doptimize=ReleaseSmall -Dno-langref -Dno-autodocs -Dno-lib
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,9 +1,10 @@
 {
-  "name": "zls-wasm",
+  "name": "playground",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
+      "name": "playground",
       "dependencies": {
         "@codemirror/autocomplete": "^6.4.2",
         "@codemirror/commands": "^6.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,8 @@
 {
+  "name": "playground",
   "scripts": {
-    "bundle": "node_modules\\.bin\\rollup editor.mjs -f iife -o editor.bundle.js -p @rollup\\plugin-node-resolve"
+    "bundle": "node_modules\\.bin\\rollup editor.mjs -f iife -o editor.bundle.js -p @rollup\\plugin-node-resolve",
+    "serve": "parcel 404.html"
   },
   "dependencies": {
     "@codemirror/autocomplete": "^6.4.2",

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -91,14 +91,10 @@ let editor = (async () => {
             doc:
     (await getPaste()) ?? `const std = @import("std");
 
-pub fn main() u8 {
+pub fn main() !void {
     std.debug.print("All your {s} are belong to us.\\n", .{"codebase"});
 
-    // WASI mains don't support errors (we can fix this with a horrible
-    // wrapper hack in the future :P)
-    std.io.getStdOut().writer().writeAll("bruh") catch return 1;
-
-    return 0;
+    try std.io.getStdOut().writer().writeAll("bruh");
 }
 `,
             extensions: [basicSetup, oneDark, indentUnit.of("    "), client.createPlugin("file:///main.zig", "zig", true), keymap.of([indentWithTab]),],

--- a/src/workers/zig.ts
+++ b/src/workers/zig.ts
@@ -71,7 +71,10 @@ async function run(source: string) {
 
     const {libStd, wasm} = await wasmData;
 
-    let args = ["zig.wasm", "build-exe", "main.zig", "-Dtarget=wasm32-wasi"];
+    // -fno-llvm -fno-lld is set explicitly to ensure the native WASM backend is
+    // used in preference to LLVM. This may be removable once the non-LLVM
+    // backends become more mature.
+    let args = ["zig.wasm", "build-exe", "main.zig", "-Dtarget=wasm32-wasi", "-fno-llvm", "-fno-lld"];
     let env = [];
     let fds = [
         stdin, // stdin


### PR DESCRIPTION
I was actually looking into the possibility of doing something just like this when I found this project 😄 I had to make some changes to get it running on my end with the latest Zig master, and noticed a few places where the documentation and other setup could be improved.

The binary Zig compiler WASM blob is unfortunate; I rebuilt it using the latest Zig master at the time of writing, but you may want to rebuild it yourself for security reasons (and in case it gets out of date relative to the stdlib and ZLS which are automatically downloaded by the CI).